### PR TITLE
Make siege-mode.el more package complient

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,22 @@ by calling `siege-explicit-call`, bound to "M-s M-s".
 
 All changes are dynamically displayed in the buffer (see `siege-preview-face`)
 and may be committed by "Ret" in the minibuffer. It is also possible to commit
-the input on "space" as set by `siege-default-end-on-space` and toggled by 
+the input on "space" as set by `siege-default-end-on-space` and toggled by
 "C-c s" in the minibuffer.
 
 By default siege-mode understands the usual delimeter pairs, as well as latex
 LaTeX begin/end pairs and left/right pairs. Moreover, for ease of use it will
 pair both `_{` and `^{` with `}` by default.
+
+## Installation
+
+To install the package, you use [quelpa-use-package](https://github.com/quelpa/quelpa-use-package/)
+
+```elisp
+  (use-package siege-mode
+    :ensure quelpa
+    :quelpa (siege-mode :repo "tslilc/siege-mode" :fetcher github))
+```
 
 ## License
 

--- a/siege-mode.el
+++ b/siege-mode.el
@@ -1,12 +1,15 @@
-;;; Package --- Surround region with smart delimiters interactively
-;; Time-stamp: <2018-07-10 18:33:54 (tslil)>
+;;; siege-mode.el --- Surround region with smart delimiters interactively
 
 ;; Copyright (c) 2018 tslil clingman
 
 ;; Author: tslil clingman <tslil@posteo.de>
 ;; Version: 2.2
+;; Package-Version: 20180710.1841
 ;; Package-Requires: ((emacs "24.4"))
-;; Keywords: region wrap
+;; URL: https://github.com/tslilc/siege-mode
+;; Keywords: convenience region wrap
+
+;; This file is NOT part of GNU Emacs.
 
 ;;; License:
 
@@ -24,7 +27,7 @@
 ;;; Commentary:
 
 ;; Lay siege to the region from both sides!
-;; 
+;;
 ;; When the region is active, most input* is redirected to the minibuffer and
 ;; treated as a delimiter for the region. The input is used as the left
 ;; delimiter from which the right one is derived using `siege-transform-regexs'


### PR DESCRIPTION
As I am massively using use-package (and quelpa-use-package) I did some minor adaptations to be able to install siege-mode directly using quelpa-use-package. Maybe it will be useful for some people.